### PR TITLE
Add shebang for UNIX compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from scripts.helpers.GUI import *
 
 if __name__ == "__main__":


### PR DESCRIPTION
This line at the top will be ignored on Windows, however on Mac or Linux it directs the shell to run the file with python - see https://realpython.com/python-shebang/.

Changed file permissions on UNIX systems to 775, this allows the file to be run by anyone on the machine, read by anyone on the machine, and modified by the owner and members of the file group.